### PR TITLE
New feature: postargs

### DIFF
--- a/.github/workflows/test-postargs.yml
+++ b/.github/workflows/test-postargs.yml
@@ -1,0 +1,52 @@
+name: Test PostArgs
+
+on:
+  pull_request:
+  push:
+
+jobs:
+
+  test-default:
+    runs-on: ubuntu-latest
+    steps:
+      - {name: Check out repository code, uses: actions/checkout@v2}
+      - {name: Copy test files, run: "cp -v tests/test-postargs/* ."}
+      - {name: Initialize dependencies, uses: ./}
+      - name: Verify dependencies
+        run: |
+          set -x
+          poetry run pip freeze
+          poetry run pip freeze |cut -d" " -f1 |tee /tmp/installed.txt
+          grep -iFx pygments /tmp/installed.txt  # Include
+          ! grep -iFx flake8 /tmp/installed.txt  # Exclude
+          ! grep -iFx beautifulsoup4 /tmp/installed.txt  # Exclude
+
+  test-postargs:
+    runs-on: ubuntu-latest
+    steps:
+      - {name: Check out repository code, uses: actions/checkout@v2}
+      - {name: Copy test files, run: "cp -v tests/test-postargs/* ."}
+      - {name: Initialize dependencies, uses: ./, with: {postargs: "-E bs4"}}
+      - name: Verify dependencies
+        run: |
+          set -x
+          poetry run pip freeze
+          poetry run pip freeze |cut -d" " -f1 |tee /tmp/installed.txt
+          grep -iFx pygments /tmp/installed.txt  # Include
+          ! grep -iFx flake8 /tmp/installed.txt  # Exclude
+          grep -iFx beautifulsoup4 /tmp/installed.txt  # Include
+
+  test-postargs-dev-deps:
+    runs-on: ubuntu-latest
+    steps:
+      - {name: Check out repository code, uses: actions/checkout@v2}
+      - {name: Copy test files, run: "cp -v tests/test-postargs/* ."}
+      - {name: Initialize dependencies, uses: ./, with: {postargs: "-E bs4", no-dev-deps: "false"}}
+      - name: Verify dependencies
+        run: |
+          set -x
+          poetry run pip freeze
+          poetry run pip freeze |cut -d" " -f1 |tee /tmp/installed.txt
+          grep -iFx pygments /tmp/installed.txt  # Include
+          grep -iFx flake8 /tmp/installed.txt  # Include
+          grep -iFx beautifulsoup4 /tmp/installed.txt  # Include

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,10 @@ inputs:
     description: Command to install project dependencies without dev-dependencies
     required: false
     default: "poetry install --no-dev"
+  postargs:
+    description: Append arguments to the install command
+    required: false
+    default: ""
 
 
 runs:
@@ -44,7 +48,7 @@ runs:
       id: cache
       uses: actions/cache@v2
       with:
-        key: "${{ runner.os }}-venv-${{ hashFiles('poetry.lock') }}-${{ inputs.no-dev-deps }}-${{ inputs.cache-buster }}"
+        key: "${{ runner.os }}-venv-${{ hashFiles('poetry.lock') }}-${{ join(inputs.*, '@') }}"
         path: .venv
 
     - name: Validate venv
@@ -65,7 +69,8 @@ runs:
     - name: Install dependencies
       if: "steps.validate.outputs.is-valid != 'true'"
       shell: bash
-      run: "${{ inputs.no-dev-deps == 'true' && inputs.install-cmd-no-dev || inputs.install-cmd }}"
+      env: {INSTALL_CMD: "${{ inputs.no-dev-deps == 'true' && inputs.install-cmd-no-dev || inputs.install-cmd }}"}
+      run: "${{ env.INSTALL_CMD }} ${{ inputs.postargs }}"
 
     - name: Validate venv
       if: "steps.validate.outputs.is-valid != 'true'"
@@ -97,3 +102,6 @@ outputs:
   install-cmd-no-dev:
     description: Same as input
     value: ${{ inputs.install-cmd-no-dev }}
+  postargs:
+    description: Same as input
+    value: ${{ inputs.postargs }}

--- a/tests/test-postargs/poetry.lock
+++ b/tests/test-postargs/poetry.lock
@@ -1,0 +1,154 @@
+[[package]]
+name = "beautifulsoup4"
+version = "4.10.0"
+description = "Screen-scraping library"
+category = "main"
+optional = true
+python-versions = ">3.0.0"
+
+[package.dependencies]
+soupsieve = ">1.2"
+
+[package.extras]
+html5lib = ["html5lib"]
+lxml = ["lxml"]
+
+[[package]]
+name = "flake8"
+version = "4.0.1"
+description = "the modular source code checker: pep8 pyflakes and co"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+importlib-metadata = {version = "<4.3", markers = "python_version < \"3.8\""}
+mccabe = ">=0.6.0,<0.7.0"
+pycodestyle = ">=2.8.0,<2.9.0"
+pyflakes = ">=2.4.0,<2.5.0"
+
+[[package]]
+name = "importlib-metadata"
+version = "4.2.0"
+description = "Read metadata from Python packages"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
+zipp = ">=0.5"
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
+
+[[package]]
+name = "mccabe"
+version = "0.6.1"
+description = "McCabe checker, plugin for flake8"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "pycodestyle"
+version = "2.8.0"
+description = "Python style guide checker"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "pyflakes"
+version = "2.4.0"
+description = "passive checker of Python programs"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "pygments"
+version = "2.11.2"
+description = "Pygments is a syntax highlighting package written in Python."
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
+name = "soupsieve"
+version = "2.3.1"
+description = "A modern CSS selector implementation for Beautiful Soup."
+category = "main"
+optional = true
+python-versions = ">=3.6"
+
+[[package]]
+name = "typing-extensions"
+version = "4.1.1"
+description = "Backported and Experimental Type Hints for Python 3.6+"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "zipp"
+version = "3.7.0"
+description = "Backport of pathlib-compatible object wrapper for zip files"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
+
+[extras]
+bs4 = ["beautifulsoup4"]
+
+[metadata]
+lock-version = "1.1"
+python-versions = "^3.7"
+content-hash = "d444af352dbbf3393b5b2993fd3fb03d23987eba2408520110f29a239b0ba07b"
+
+[metadata.files]
+beautifulsoup4 = [
+    {file = "beautifulsoup4-4.10.0-py3-none-any.whl", hash = "sha256:9a315ce70049920ea4572a4055bc4bd700c940521d36fc858205ad4fcde149bf"},
+    {file = "beautifulsoup4-4.10.0.tar.gz", hash = "sha256:c23ad23c521d818955a4151a67d81580319d4bf548d3d49f4223ae041ff98891"},
+]
+flake8 = [
+    {file = "flake8-4.0.1-py2.py3-none-any.whl", hash = "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d"},
+    {file = "flake8-4.0.1.tar.gz", hash = "sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d"},
+]
+importlib-metadata = [
+    {file = "importlib_metadata-4.2.0-py3-none-any.whl", hash = "sha256:057e92c15bc8d9e8109738a48db0ccb31b4d9d5cfbee5a8670879a30be66304b"},
+    {file = "importlib_metadata-4.2.0.tar.gz", hash = "sha256:b7e52a1f8dec14a75ea73e0891f3060099ca1d8e6a462a4dff11c3e119ea1b31"},
+]
+mccabe = [
+    {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
+    {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
+]
+pycodestyle = [
+    {file = "pycodestyle-2.8.0-py2.py3-none-any.whl", hash = "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20"},
+    {file = "pycodestyle-2.8.0.tar.gz", hash = "sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f"},
+]
+pyflakes = [
+    {file = "pyflakes-2.4.0-py2.py3-none-any.whl", hash = "sha256:3bb3a3f256f4b7968c9c788781e4ff07dce46bdf12339dcda61053375426ee2e"},
+    {file = "pyflakes-2.4.0.tar.gz", hash = "sha256:05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c"},
+]
+pygments = [
+    {file = "Pygments-2.11.2-py3-none-any.whl", hash = "sha256:44238f1b60a76d78fc8ca0528ee429702aae011c265fe6a8dd8b63049ae41c65"},
+    {file = "Pygments-2.11.2.tar.gz", hash = "sha256:4e426f72023d88d03b2fa258de560726ce890ff3b630f88c21cbb8b2503b8c6a"},
+]
+soupsieve = [
+    {file = "soupsieve-2.3.1-py3-none-any.whl", hash = "sha256:1a3cca2617c6b38c0343ed661b1fa5de5637f257d4fe22bd9f1338010a1efefb"},
+    {file = "soupsieve-2.3.1.tar.gz", hash = "sha256:b8d49b1cd4f037c7082a9683dfa1801aa2597fb11c3a1155b7a5b94829b4f1f9"},
+]
+typing-extensions = [
+    {file = "typing_extensions-4.1.1-py3-none-any.whl", hash = "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2"},
+    {file = "typing_extensions-4.1.1.tar.gz", hash = "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42"},
+]
+zipp = [
+    {file = "zipp-3.7.0-py3-none-any.whl", hash = "sha256:b47250dd24f92b7dd6a0a8fc5244da14608f3ca90a5efcd37a3b1642fac9a375"},
+    {file = "zipp-3.7.0.tar.gz", hash = "sha256:9f50f446828eb9d45b267433fd3e9da8d801f614129124863f9c51ebceafb87d"},
+]

--- a/tests/test-postargs/pyproject.toml
+++ b/tests/test-postargs/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["poetry>=0.12"]
+build-backend = "poetry.masonry.api"
+
+[tool.poetry]
+name = "Test"
+version = "0.0.1"
+description = "Mock project."
+authors = ["Robpol86 <robpol86@gmail.com>"]
+license = "BSD-2-Clause"
+classifiers = [
+    "Private :: Do Not Upload",
+]
+
+[tool.poetry.urls]
+repository = "https://github.com/Robpol86/actions-init-deps-py"
+
+[tool.poetry.dependencies]
+python = "^3.7"
+pygments = "*"  # Arbitrary dependency.
+beautifulsoup4 = {version = "*", optional = true}  # Arbitrary dependency.
+
+[tool.poetry.extras]
+bs4 = [
+    "beautifulsoup4",
+]
+
+[tool.poetry.dev-dependencies]
+flake8 = "*"  # Arbitrary dependency.


### PR DESCRIPTION
Use case: `poetry install -E docs`

Also using all inputs when deriving the cache key instead of adding them
one by one when new inputs are added. Prevents cache collisions.