### PR TITLE
Allow overriding any command with install-cmd.

### DIFF
--- a/.github/workflows/test-install-cmd.yml
+++ b/.github/workflows/test-install-cmd.yml
@@ -53,3 +53,39 @@ jobs:
         run: |
           set -ux
           test "$INSTALL_CMD_OUT" == "poetry install --no-dev && ls"
+
+  test-install-cmd:
+    runs-on: ubuntu-latest
+    steps:
+      - {name: Check out repository code, uses: actions/checkout@v2}
+      - {name: Copy test files, run: 'cp -v "tests/$TEST_FILES"/* .'}
+      - {name: Init, id: init, uses: ./, with: {cache-buster: "${{ env.CACHE_BUSTER }}", install-cmd: "poetry install --dry-run"}}
+      - name: Verify
+        env: {INSTALL_CMD_OUT: "${{ steps.init.outputs.install-cmd-out }}"}
+        run: |
+          set -ux
+          test "$INSTALL_CMD_OUT" == "poetry install --dry-run"
+
+  test-install-cmd-no-dev:
+    runs-on: ubuntu-latest
+    steps:
+      - {name: Check out repository code, uses: actions/checkout@v2}
+      - {name: Copy test files, run: 'cp -v "tests/$TEST_FILES"/* .'}
+      - {name: Init, id: init, uses: ./, with: {cache-buster: "${{ env.CACHE_BUSTER }}", install-cmd: "poetry install --dry-run", no-dev: "true"}}
+      - name: Verify
+        env: {INSTALL_CMD_OUT: "${{ steps.init.outputs.install-cmd-out }}"}
+        run: |
+          set -ux
+          test "$INSTALL_CMD_OUT" == "poetry install --dry-run"
+
+  test-install-cmd-postargs:
+    runs-on: ubuntu-latest
+    steps:
+      - {name: Check out repository code, uses: actions/checkout@v2}
+      - {name: Copy test files, run: 'cp -v "tests/$TEST_FILES"/* .'}
+      - {name: Init, id: init, uses: ./, with: {cache-buster: "${{ env.CACHE_BUSTER }}", install-cmd: "poetry install --dry-run", postargs: " && ls"}}
+      - name: Verify
+        env: {INSTALL_CMD_OUT: "${{ steps.init.outputs.install-cmd-out }}"}
+        run: |
+          set -ux
+          test "$INSTALL_CMD_OUT" == "poetry install --dry-run && ls"

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,10 @@ inputs:
     description: Python version to install
     required: false
     default: "3.10"
+  install-cmd:
+    description: Override poetry install command, overrides no-dev and poetry-install-cmd*
+    required: false
+    default: ""
   no-dev:
     description: Whether to exclude tool.poetry.dev-dependencies in pyproject.toml
     required: false
@@ -72,10 +76,16 @@ runs:
       id: install
       if: "steps.validate.outputs.is-valid != 'true'"
       shell: bash
-      env: {INSTALL_CMD: "${{ inputs.no-dev == 'true' && inputs.poetry-install-cmd-no-dev || inputs.poetry-install-cmd }}"}
+      env:
+        INSTALL_CMD:
+          "${{
+            inputs.install-cmd || (
+              inputs.no-dev == 'true' && inputs.poetry-install-cmd-no-dev || inputs.poetry-install-cmd
+            )
+          }}${{ inputs.postargs }}"
       run: |
-        ${{ env.INSTALL_CMD }}${{ inputs.postargs }}
-        echo "::set-output name=cmd::${{ env.INSTALL_CMD }}${{ inputs.postargs }}"
+        ${{ env.INSTALL_CMD }}
+        echo "::set-output name=cmd::$INSTALL_CMD"
 
     - name: Validate venv
       id: validate2
@@ -98,6 +108,9 @@ outputs:
   python-version:
     description: Same as input
     value: ${{ inputs.python-version }}
+  install-cmd:
+    description: Same as input
+    value: ${{ inputs.install-cmd }}
   no-dev:
     description: Same as input
     value: ${{ inputs.no-dev }}


### PR DESCRIPTION
Simplify action. User no longer needs to set no-dev and one of the
poetry-install-cmd inputs if they have a custom command like a Makefile.
Instead just set install-cmd and no-dev will be ignored.