### PR TITLE
Include pyproject.toml in hashFiles.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -57,7 +57,7 @@ runs:
       id: cache
       uses: actions/cache@v2
       with:
-        key: "init-deps-py-${{ runner.os }}-venv-${{ hashFiles('poetry.lock') }}-${{ join(inputs.*, '@') }}"
+        key: "init-deps-py-${{ runner.os }}-venv-${{ hashFiles('pyproject.toml', 'poetry.lock') }}-${{ join(inputs.*, '@') }}"
         path: .venv
 
     - name: Validate venv


### PR DESCRIPTION
Some changes to pyproject.toml don't trigger changes in poetry.lock but
can break with stale caches.